### PR TITLE
Add option to add X-XSS-Protection: 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ For example:
 * If you want to load a website in an iframe, and that website uses `X-Frame-Options: SAMEORIGIN`, Chrome will refuse to show the website. Use the "Delete X-Frame-Options header" option to have Chrome ignore that restriction.
 * If you want to call a foreign AJAX endpoint from a website that has `Content-Security-Policy: ...` set to disallow wildcard script-src, use the "Delete Content-Security-Policy header" to allow running any script on that page.
 * If you want to call out to an API endpoint that doesn't specify itself as `CORS`-friendly, enable the "Add Access-Control-Allow-Origin: * header" and "Add Access-Control-Allow-Methods: * header" options.
+* If you want to test a website for reflected XSS vulnerabilities but the page is blocked by the Chrome XSS Auditor due to `X-XSS-Protection: 1` or no `X-XSS-Protection` header present, you can use "Add X-XSS-Protection: 0 header" option to load the page.
 
 Each restriction can be disabled or enabled individually; labeled checkboxes on the configuration page clearly indicate which restrictions are disabled.
 

--- a/background.js
+++ b/background.js
@@ -60,8 +60,9 @@ function responseListener(details) {
   var allow_origin_star = localStorage.origin == 'true';
   var allow_methods_star = localStorage.methods == 'true';
   var strip_frame_options = localStorage.frame_options == 'true';
+  var xss_protection_zero = localStorage.xss_protection == 'true';
 
-  var active = strip_csp || allow_origin_star || allow_methods_star || strip_frame_options;
+  var active = strip_csp || allow_origin_star || allow_methods_star || strip_frame_options || xss_protection_zero;
   // var active = active && (details.type == 'main_frame');
   if (active) {
     log('Removing headers where applicable');
@@ -78,6 +79,10 @@ function responseListener(details) {
     }
     if (strip_frame_options) {
       removeMatchingHeaders(details.responseHeaders, /x-frame-options/i);
+    }
+    if (xss_protection_zero) {
+      removeMatchingHeaders(details.responseHeaders, /x-xss-protection/i);
+      details.responseHeaders.push({name: 'X-XSS-Protection', value: '0'});
     }
   }
 

--- a/options.html
+++ b/options.html
@@ -35,6 +35,13 @@
 
     <div class="control">
       <label>
+        <input type="checkbox" name="xss_protection">
+        Add <code>X-XSS-Protection: 0</code> header
+      </label>
+    </div>
+
+    <div class="control">
+      <label>
         <input type="checkbox" name="frame_options">
         Delete <code>X-Frame-Options</code> header
       </label>
@@ -48,4 +55,3 @@
     </div>
   </body>
 </html>
-


### PR DESCRIPTION
Add an option to add `X-XSS-Protection: 0` header to the page, which might be useful when you want to test a website for reflected XSS vulnerabilities but the page is blocked by the Chrome XSS Auditor due to `X-XSS-Protection: 1` or no `X-XSS-Protection` header present.